### PR TITLE
Adjust to sbt 0.13

### DIFF
--- a/src/main/scala/org/sbtsh/SbtShPlugin.scala
+++ b/src/main/scala/org/sbtsh/SbtShPlugin.scala
@@ -1,7 +1,6 @@
 package org.sbtsh
 
 import sbt._
-import sbt.CommandSupport._
 
 object SbtShPlugin extends Plugin {
 


### PR DESCRIPTION
### steps
1. try using sbt-sh with sbt 0.13
### problem

```
[error] /Users/xxx/.sbt/0.13.0/staging/1234/sbt-sh/src/main/scala/org/sbtsh/SbtShPlugin.scala:4: object CommandSupport is not a member of package sbt
[error] import sbt.CommandSupport._
[error]            ^
[error] one error found
[error] ({git://github.com/steppenwells/sbt-sh.git}sbt-sh/compile:compile) Compilation failed
```
### what this changes

It removes the import line.
